### PR TITLE
CMAKE: Update VTK_SOURCE_DIRECTORY to VTKv9

### DIFF
--- a/SuperBuild/External_VTKRenderingOpenVR.cmake
+++ b/SuperBuild/External_VTKRenderingOpenVR.cmake
@@ -8,7 +8,7 @@ set(proj VTKRenderingOpenVR)
 set(${proj}_DEPENDENCIES OpenVR)
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
 
-set(VTK_SOURCE_DIR ${VTK_DIR}/../VTKv8)
+set(VTK_SOURCE_DIR ${VTK_DIR}/../VTKv9)
 set(${proj}_SOURCE_DIR ${VTK_SOURCE_DIR}/Rendering/OpenVR)
 ExternalProject_Message(${proj} "VTK_SOURCE_DIR:${VTK_SOURCE_DIR}")
 ExternalProject_Message(${proj} "${proj}_SOURCE_DIR:${${proj}_SOURCE_DIR}")


### PR DESCRIPTION
Slicer now builds with VTK source in <Slicer-Build-Dir>/VTKv9