### PR TITLE
ENH: Renamed VR module to Virtual Reality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.5)
 
 project(SlicerOpenVR)
 

--- a/VR/CMakeLists.txt
+++ b/VR/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 #-----------------------------------------------------------------------------
-set(MODULE_NAME VR)
-set(MODULE_TITLE ${MODULE_NAME})
+set(MODULE_NAME VirtualReality)
+set(MODULE_TITLE "Virtual Reality")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -24,29 +24,29 @@ set(MODULE_INCLUDE_DIRECTORIES
   )
 
 set(MODULE_SRCS
-  qSlicer${MODULE_NAME}Module.cxx
-  qSlicer${MODULE_NAME}Module.h
-  qSlicer${MODULE_NAME}ModuleWidget.cxx
-  qSlicer${MODULE_NAME}ModuleWidget.h
+  qSlicerVRModule.cxx
+  qSlicerVRModule.h
+  qSlicerVRModuleWidget.cxx
+  qSlicerVRModuleWidget.h
   )
 
 set(MODULE_MOC_SRCS
-  qSlicer${MODULE_NAME}Module.h
-  qSlicer${MODULE_NAME}ModuleWidget.h
+  qSlicerVRModule.h
+  qSlicerVRModuleWidget.h
   )
 
 set(MODULE_UI_SRCS
-  Resources/UI/qSlicer${MODULE_NAME}ModuleWidget.ui
+  Resources/UI/qSlicerVRModuleWidget.ui
   )
 
 set(MODULE_TARGET_LIBRARIES
-  vtkSlicer${MODULE_NAME}ModuleMRML
-  vtkSlicer${MODULE_NAME}ModuleLogic
-  qSlicer${MODULE_NAME}ModuleWidgets
+  vtkSlicerVirtualRealityModuleMRML
+  vtkSlicerVirtualRealityModuleLogic
+  qSlicerVirtualRealityModuleWidgets
   )
 
 set(MODULE_RESOURCES
-  Resources/qSlicer${MODULE_NAME}Module.qrc
+  Resources/qSlicerVRModule.qrc
   )
 
 #-----------------------------------------------------------------------------
@@ -60,7 +60,7 @@ slicerMacroBuildLoadableModule(
   UI_SRCS ${MODULE_UI_SRCS}
   TARGET_LIBRARIES ${MODULE_TARGET_LIBRARIES}
   RESOURCES ${MODULE_RESOURCES}
-  WITH_GENERIC_TESTS
+  # WITH_GENERIC_TESTS
   )
 
 #-----------------------------------------------------------------------------

--- a/VR/Logic/CMakeLists.txt
+++ b/VR/Logic/CMakeLists.txt
@@ -8,8 +8,8 @@ set(${KIT}_INCLUDE_DIRECTORIES
   )
 
 set(${KIT}_SRCS
-  vtkSlicer${MODULE_NAME}Logic.cxx
-  vtkSlicer${MODULE_NAME}Logic.h
+  vtkSlicerVRLogic.cxx
+  vtkSlicerVRLogic.h
   )
 
 set(${KIT}_TARGET_LIBRARIES

--- a/VR/Logic/vtkSlicerVRLogic.h
+++ b/VR/Logic/vtkSlicerVRLogic.h
@@ -32,11 +32,11 @@
 // STD includes
 #include <cstdlib>
 
-#include "vtkSlicerVRModuleLogicExport.h"
+#include "vtkSlicerVirtualRealityModuleLogicExport.h"
 
 
 /// \ingroup Slicer_QtModules_ExtensionTemplate
-class VTK_SLICER_VR_MODULE_LOGIC_EXPORT vtkSlicerVRLogic :
+class VTK_SLICER_VIRTUALREALITY_MODULE_LOGIC_EXPORT vtkSlicerVRLogic :
   public vtkSlicerModuleLogic
 {
 public:

--- a/VR/MRML/CMakeLists.txt
+++ b/VR/MRML/CMakeLists.txt
@@ -8,10 +8,12 @@ set(${KIT}_INCLUDE_DIRECTORIES
   )
 
 set(${KIT}_SRCS
-  vtkMRML${MODULE_NAME}ViewDisplayableManagerFactory.cxx
-  vtkMRML${MODULE_NAME}ViewDisplayableManagerFactory.h
-  vtkMRML${MODULE_NAME}ViewNode.cxx
-  vtkMRML${MODULE_NAME}ViewNode.h
+  vtkMRMLVRViewDisplayableManagerFactory.cxx
+  vtkMRMLVRViewDisplayableManagerFactory.h
+  vtkMRMLVRViewNode.cxx
+  vtkMRMLVRViewNode.h
+  vtkMRMLVRLayoutNode.cxx
+  vtkMRMLVRLayoutNode.h
   )
 
 set(${KIT}_TARGET_LIBRARIES

--- a/VR/MRML/vtkMRMLVRLayoutNode.cxx
+++ b/VR/MRML/vtkMRMLVRLayoutNode.cxx
@@ -1,0 +1,197 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through CANARIE’s Research Software Program, and Cancer
+  Care Ontario.
+
+==============================================================================*/
+
+// STL includes
+#include <sstream>
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+
+// MRML includes
+#include "vtkMRMLVRLayoutNode.h"
+
+//----------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLVRLayoutNode);
+
+//----------------------------------------------------------------------------
+vtkMRMLVRLayoutNode::vtkMRMLVRLayoutNode()
+{
+  this->SetSingletonTag("vtkMRMLVRLayoutNode");
+
+  this->CurrentLayoutDescription = NULL;
+
+  // Synchronize the view description with the layout
+  //TODO:
+  //this->AddLayoutDescription(vtkMRMLVRLayoutNode::SlicerLayoutNone, "");
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLVRLayoutNode::~vtkMRMLVRLayoutNode()
+{
+  this->SetCurrentLayoutDescription(0);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLVRLayoutNode::WriteXML(ostream& of, int nIndent)
+{
+  // Write all attributes, since the parsing of the string is dependent on the
+  // order here.
+
+  Superclass::WriteXML(of, nIndent);
+
+  //of << " layout=\"" << this->CurrentLayoutDescription << "\"";
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLVRLayoutNode::ReadXMLAttributes(const char** atts)
+{
+  int disabledModify = this->StartModify();
+
+  Superclass::ReadXMLAttributes(atts);
+
+  const char* attName;
+  const char* attValue;
+
+  while (*atts != NULL)
+    {
+    attName = *(atts++);
+    attValue = *(atts++);
+    if ( !strcmp(attName, "layout"))
+      {
+      //this->SetAndParseCurrentLayoutDescription(attValue);
+      }
+    }
+
+  this->EndModify(disabledModify);
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLVRLayoutNode::AddLayoutDescription(int layout, const char* layoutDescription)
+{
+  if (this->IsLayoutDescription(layout))
+    {
+    vtkDebugMacro( << "Layout " << layout << " has already been registered");
+    return false;
+    }
+  this->Layouts[layout] = std::string(layoutDescription);
+  this->Modified();
+  return true;
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLVRLayoutNode::SetLayoutDescription(int layout, const char* layoutDescription)
+{
+  if (!this->IsLayoutDescription(layout))
+    {
+    vtkDebugMacro( << "Layout " << layout << " has NOT been registered");
+    return false;
+    }
+  if (this->Layouts[layout] == layoutDescription)
+    {
+    return true;
+    }
+  this->Layouts[layout] = std::string(layoutDescription);
+  int wasModifying = this->StartModify();
+  this->UpdateCurrentLayoutDescription();
+  this->Modified();
+  this->EndModify(wasModifying);
+  return true;
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLVRLayoutNode::IsLayoutDescription(int layout)
+{
+  std::map<int, std::string>::const_iterator it = this->Layouts.find(layout);
+  return it != this->Layouts.end();
+}
+
+//----------------------------------------------------------------------------
+std::string vtkMRMLVRLayoutNode::GetLayoutDescription(int layout)
+{
+  std::map<int, std::string>::const_iterator it = this->Layouts.find(layout);
+  if (it == this->Layouts.end())
+    {
+    vtkWarningMacro("Can't find layout:" << layout);
+    return std::string();
+    }
+  return it->second;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLVRLayoutNode::UpdateCurrentLayoutDescription()
+{
+  //if (this->GetViewArrangement() == vtkMRMLVRLayoutNode::SlicerLayoutCustomView)
+  //  {
+  //  return;
+  //  }
+  //std::string description = this->GetLayoutDescription(this->ViewArrangement);
+  //if (this->GetCurrentLayoutDescription() &&
+  //    description == this->GetCurrentLayoutDescription())
+  //  {
+  //  return;
+  //  }
+  //this->SetAndParseCurrentLayoutDescription(description.c_str());
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLVRLayoutNode::SetAndParseCurrentLayoutDescription(const char* description)
+{
+  //// Be careful that it matches the ViewArrangement value
+  //if (this->LayoutRootElement)
+  //  {
+  //  this->LayoutRootElement->Delete();
+  //  }
+  //this->LayoutRootElement = this->ParseLayout(description);
+  //if (this->LayoutRootElement == NULL)
+  //  {
+  //  // ParseLayout has already logged an error, if there was any
+  //  this->SetCurrentLayoutDescription("");
+  //  return;
+  //  }
+
+  //this->SetCurrentLayoutDescription(description);
+}
+
+//----------------------------------------------------------------------------
+// Copy the node's attributes to this object.
+// Does NOT copy: ID, FilePrefix, LabelText, ID
+void vtkMRMLVRLayoutNode::Copy(vtkMRMLNode *anode)
+{
+  int disabledModify = this->StartModify();
+
+  //vtkObject::Copy(anode);
+  vtkMRMLVRLayoutNode *node = (vtkMRMLVRLayoutNode*)anode;
+  // Try to copy the registered layout descriptions. However, if the node
+  // currently has layout descriptions (more than the default None description)
+  // then we don't want to copy them (it would overwrite the descriptions)
+  if (node->Layouts.size() > 1 && this->Layouts.size() == 1)
+    {
+    this->Layouts = node->Layouts;
+    }
+
+  this->EndModify(disabledModify);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLVRLayoutNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  Superclass::PrintSelf(os,indent);
+}

--- a/VR/MRML/vtkMRMLVRLayoutNode.h
+++ b/VR/MRML/vtkMRMLVRLayoutNode.h
@@ -1,0 +1,99 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through CANARIE’s Research Software Program, and Cancer
+  Care Ontario.
+
+==============================================================================*/
+
+#ifndef __vtkMRMLVRLayoutNode_h
+#define __vtkMRMLVRLayoutNode_h
+
+// MRML includes
+#include "vtkMRMLAbstractLayoutNode.h"
+
+#include "vtkSlicerVirtualRealityModuleMRMLExport.h"
+
+/// \brief Node that describes the virtual reality layout of the application.
+class VTK_SLICER_VIRTUALREALITY_MODULE_MRML_EXPORT vtkMRMLVRLayoutNode : public vtkMRMLAbstractLayoutNode
+{
+public:
+  static vtkMRMLVRLayoutNode *New();
+  vtkTypeMacro(vtkMRMLVRLayoutNode,vtkMRMLAbstractLayoutNode);
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+
+  //--------------------------------------------------------------------------
+  /// MRML methods
+  //--------------------------------------------------------------------------
+
+  /// Set node attributes
+  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
+
+  /// Write this node's information to a MRML file in XML format.
+  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
+
+  /// Copy the node's attributes to this object
+  virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
+
+  /// Get node XML tag name (like Volume, Model)
+  virtual const char* GetNodeTagName() VTK_OVERRIDE {return "VRLayout";}
+
+  /// Adds a layout description with integer identifier
+  /// "layout". Returns false without making any modifications if the
+  /// integer identifier "layout" has already been added.
+  bool AddLayoutDescription(int layout, const char* layoutDescription);
+
+  /// Modifies a layout description for integer identifier
+  /// "layout". Returns false without making any modifications if the
+  /// integer identifier "layout" has NOT already been added.
+  bool SetLayoutDescription(int layout, const char* layoutDescription);
+
+  /// Query whether a layout exists with a specified integer identifier
+  bool IsLayoutDescription(int layout);
+
+  /// Get the layout description associated with a specified integer
+  /// identifier. The empty string is returned if the layout does not exist.
+  std::string GetLayoutDescription(int layout);
+
+  // Get the layout description currently displayed. Used
+  // internally. This is XML description corresponding to the ivar
+  // ViewArrangement which is the integer identifier for the
+  // layout. ViewArrangement and CurrentViewDescription may not
+  // correspond while a view is being switched.
+  vtkGetStringMacro(CurrentLayoutDescription);
+
+  //TODO: Add features to handle heads-up display. It is unlikely that the VR layouts can use
+  // the same API as the Slicer layouts, because they are not a Qt layouts, just stationary
+  // 2D panels in the 3D scene.
+  // A new displayable manager will be needed to handle these HUD views
+
+protected:
+  void UpdateCurrentLayoutDescription();
+  void SetAndParseCurrentLayoutDescription(const char* description);
+  vtkSetStringMacro(CurrentLayoutDescription);
+
+protected:
+  vtkMRMLVRLayoutNode();
+  ~vtkMRMLVRLayoutNode();
+  vtkMRMLVRLayoutNode(const vtkMRMLVRLayoutNode&);
+  void operator=(const vtkMRMLVRLayoutNode&);
+
+  //TODO: Are layout descriptions needed like this? If so, sink this into abstract layout
+  std::map<int, std::string> Layouts;
+  char*                      CurrentLayoutDescription;
+};
+
+#endif

--- a/VR/MRML/vtkMRMLVRViewDisplayableManagerFactory.h
+++ b/VR/MRML/vtkMRMLVRViewDisplayableManagerFactory.h
@@ -27,7 +27,7 @@
 // VTK includes
 #include <vtkSingleton.h>
 
-#include "vtkSlicerVRModuleMRMLExport.h"
+#include "vtkSlicerVirtualRealityModuleMRMLExport.h"
 
 class vtkRenderer;
 
@@ -35,7 +35,7 @@ class vtkRenderer;
 ///
 /// A displayable manager class is responsible to represente a
 /// MRMLDisplayable node in a renderer.
-class VTK_SLICER_VR_MODULE_MRML_EXPORT vtkMRMLVRViewDisplayableManagerFactory
+class VTK_SLICER_VIRTUALREALITY_MODULE_MRML_EXPORT vtkMRMLVRViewDisplayableManagerFactory
   : public vtkMRMLDisplayableManagerFactory
 {
 public:
@@ -69,7 +69,7 @@ private:
 
 #ifndef __VTK_WRAP__
 //BTX
-VTK_SINGLETON_DECLARE_INITIALIZER(VTK_SLICER_VR_MODULE_MRML_EXPORT,
+VTK_SINGLETON_DECLARE_INITIALIZER(VTK_SLICER_VIRTUALREALITY_MODULE_MRML_EXPORT,
                                   vtkMRMLVRViewDisplayableManagerFactory);
 //ETX
 #endif // __VTK_WRAP__

--- a/VR/MRML/vtkMRMLVRViewNode.cxx
+++ b/VR/MRML/vtkMRMLVRViewNode.cxx
@@ -96,7 +96,18 @@ void vtkMRMLVRViewNode::Copy(vtkMRMLNode *anode)
 void vtkMRMLVRViewNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->Superclass::PrintSelf(os,indent);
+}
 
+//----------------------------------------------------------------------------
+void vtkMRMLVRViewNode::SetSceneReferences()
+{
+  if (!this->Scene)
+    {
+    vtkErrorMacro(<< "SetSceneReferences: Scene is expected to be non NULL.");
+    return;
+    }
+
+  this->SetAndObserveParentLayoutNode(this);
 }
 
 //------------------------------------------------------------------------------

--- a/VR/MRML/vtkMRMLVRViewNode.h
+++ b/VR/MRML/vtkMRMLVRViewNode.h
@@ -18,12 +18,12 @@
 // VTK includes
 #include "vtkMRMLViewNode.h"
 
-#include "vtkSlicerVRModuleMRMLExport.h"
+#include "vtkSlicerVirtualRealityModuleMRMLExport.h"
 
 /// \brief MRML node to represent a 3D view.
 ///
 /// View node contains view parameters.
-class VTK_SLICER_VR_MODULE_MRML_EXPORT vtkMRMLVRViewNode
+class VTK_SLICER_VIRTUALREALITY_MODULE_MRML_EXPORT vtkMRMLVRViewNode
   : public vtkMRMLViewNode
 {
 public:
@@ -52,6 +52,9 @@ public:
   ///
   /// Get node XML tag name (like Volume, Model)
   virtual const char* GetNodeTagName() VTK_OVERRIDE;
+
+  /// Update the references of the node to the scene.
+  virtual void SetSceneReferences();
 
   /// Return the color the view nodes have for the background by default.
   static double* defaultBackgroundColor();

--- a/VR/Widgets/qMRMLVRView.cxx
+++ b/VR/Widgets/qMRMLVRView.cxx
@@ -296,7 +296,7 @@ void qMRMLVRView::addDisplayableManager(const QString& displayableManagerName)
 void qMRMLVRView::startVR()
 {
   Q_D(qMRMLVRView);
-  qDebug() << "startVR";
+  qDebug() << Q_FUNC_INFO << "Start VR";
   d->VRLoopTimer.start(0);
 }
 
@@ -304,7 +304,7 @@ void qMRMLVRView::startVR()
 void qMRMLVRView::stopVR()
 {
   Q_D(qMRMLVRView);
-  qDebug() << "stopVR";
+  qDebug() << Q_FUNC_INFO << "Stop VR";
   d->VRLoopTimer.stop();
 }
 
@@ -329,7 +329,6 @@ void qMRMLVRView::setMRMLVRViewNode(vtkMRMLVRViewNode* newViewNode)
     return;
     }
 
-
   d->qvtkReconnect(
     d->MRMLVRViewNode, newViewNode,
     vtkCommand::ModifiedEvent, d, SLOT(updateWidgetFromMRML()));
@@ -338,6 +337,7 @@ void qMRMLVRView::setMRMLVRViewNode(vtkMRMLVRViewNode* newViewNode)
   d->DisplayableManagerGroup->SetMRMLDisplayableNode(newViewNode);
 
   d->updateWidgetFromMRML();
+
   // Enable/disable widget
   this->setEnabled(newViewNode != 0);
 }

--- a/VR/Widgets/qMRMLVRView.h
+++ b/VR/Widgets/qMRMLVRView.h
@@ -28,7 +28,7 @@
 // Qt includes
 #include <QWidget>
 
-#include "qSlicerVRModuleWidgetsExport.h"
+#include "qSlicerVirtualRealityModuleWidgetsExport.h"
 
 class qMRMLVRViewPrivate;
 class vtkMRMLScene;
@@ -43,10 +43,10 @@ class vtkOpenVRRenderWindowInteractor;
 class vtkOpenVRCamera;
 
 /// \brief 3D view for view nodes.
-/// For performance reasons, the view block refreshs when the scene is in
+/// For performance reasons, the view block refreshes when the scene is in
 /// batch process state.
 /// \sa qMRMLVRWidget, qMRMLVRViewControllerWidget, qMRMLSliceView
-class Q_SLICER_QTMODULES_VR_WIDGETS_EXPORT qMRMLVRView : public QWidget
+class Q_SLICER_QTMODULES_VIRTUALREALITY_WIDGETS_EXPORT qMRMLVRView : public QWidget
 {
   Q_OBJECT
 public:
@@ -85,9 +85,9 @@ public:
   Q_INVOKABLE vtkOpenVRRenderWindowInteractor* interactor()const;
 
 public slots:
-
   void startVR();
   void stopVR();
+
   /// Set the MRML \a scene that should be listened for events
   /// When the scene is in batch process state, the view blocks all refresh.
   /// \sa renderEnabled
@@ -98,7 +98,6 @@ public slots:
 
   /// Enable/Disable rendering
   void setRenderEnabled(bool value);
-
 
 protected:
   QScopedPointer<qMRMLVRViewPrivate> d_ptr;

--- a/VR/Widgets/qMRMLVRView_p.h
+++ b/VR/Widgets/qMRMLVRView_p.h
@@ -76,19 +76,18 @@ public slots:
 
   void updateWidgetFromMRML();
 
-
   void doOpenVR();
 
 protected:
   void initDisplayableManagers();
 
-  vtkMRMLDisplayableManagerGroup*    DisplayableManagerGroup;
-  vtkMRMLScene*                      MRMLScene;
-  vtkMRMLVRViewNode*                 MRMLVRViewNode;
-  bool                               RenderEnabled;
-  vtkSmartPointer<vtkOpenVRRenderer>       Renderer;
-  vtkSmartPointer<vtkOpenVRRenderWindow>   RenderWindow;
-  vtkSmartPointer<vtkOpenVRRenderWindowInteractor>   Interactor;
+  vtkMRMLDisplayableManagerGroup* DisplayableManagerGroup;
+  vtkMRMLScene* MRMLScene;
+  vtkMRMLVRViewNode* MRMLVRViewNode;
+  bool RenderEnabled;
+  vtkSmartPointer<vtkOpenVRRenderer> Renderer;
+  vtkSmartPointer<vtkOpenVRRenderWindow> RenderWindow;
+  vtkSmartPointer<vtkOpenVRRenderWindowInteractor> Interactor;
   vtkSmartPointer<vtkOpenVRCamera> Camera;
 
   QTimer VRLoopTimer;

--- a/VR/qSlicerVRModule.cxx
+++ b/VR/qSlicerVRModule.cxx
@@ -91,7 +91,7 @@ QIcon qSlicerVRModule::icon() const
 //-----------------------------------------------------------------------------
 QStringList qSlicerVRModule::categories() const
 {
-  return QStringList() << "Examples";
+  return QStringList() << "Virtual Reality";
 }
 
 //-----------------------------------------------------------------------------

--- a/VR/qSlicerVRModule.h
+++ b/VR/qSlicerVRModule.h
@@ -21,14 +21,13 @@
 // SlicerQt includes
 #include "qSlicerLoadableModule.h"
 
-#include "qSlicerVRModuleExport.h"
+#include "qSlicerVirtualRealityModuleExport.h"
 
 class qSlicerVRModulePrivate;
 
 /// \ingroup Slicer_QtModules_ExtensionTemplate
-class Q_SLICER_QTMODULES_VR_EXPORT
-qSlicerVRModule
-  : public qSlicerLoadableModule
+class Q_SLICER_QTMODULES_VIRTUALREALITY_EXPORT qSlicerVRModule :
+  public qSlicerLoadableModule
 {
   Q_OBJECT
 #ifdef Slicer_HAVE_QT5

--- a/VR/qSlicerVRModuleWidget.h
+++ b/VR/qSlicerVRModuleWidget.h
@@ -21,32 +21,33 @@
 // SlicerQt includes
 #include "qSlicerAbstractModuleWidget.h"
 
-#include "qSlicerVRModuleExport.h"
+#include "qSlicerVirtualRealityModuleExport.h"
 
 class qSlicerVRModuleWidgetPrivate;
 class vtkMRMLNode;
 class qMRMLVRView;
 
 /// \ingroup Slicer_QtModules_ExtensionTemplate
-class Q_SLICER_QTMODULES_VR_EXPORT qSlicerVRModuleWidget :
+class Q_SLICER_QTMODULES_VIRTUALREALITY_EXPORT qSlicerVRModuleWidget :
   public qSlicerAbstractModuleWidget
 {
   Q_OBJECT
 
 public:
-
   typedef qSlicerAbstractModuleWidget Superclass;
   qSlicerVRModuleWidget(QWidget *parent=0);
   virtual ~qSlicerVRModuleWidget();
+  
+  Q_INVOKABLE qMRMLVRView* vrWidget() const;
 
 public slots:
-  void onInitializePushButtonClicked();
-  void onStartVRPushButtonClicked();
-  void onStopVRPushButtonClicked();
+  void initializeVR();
+  void startVR();
+  void stopVR();
 
 protected:
   QScopedPointer<qSlicerVRModuleWidgetPrivate> d_ptr;
-  qMRMLVRView* vrWidget;
+  qMRMLVRView* m_vrWidget;
 
   virtual void setup();
 


### PR DESCRIPTION
The main reason for this was that the VR module was incorrectly added to the slicer.modules in python: the module was accessible using slicer.modules.v instead or slicer.modules.vr. This caused complications, so I decided to rename the module. Generic tests needed to be disabled.

The VR view node excludes itself from Slicer main layout management, see vtkMRMLVRViewNode::SetSceneReferences.

Accessor added in qSlicerVRModuleWidget to get the VR widget, in order to be able to decide from other modules whether VR has been initialized/started.

Added vtkMRMLVRLayoutNode skeleton WIP

Module moved from Examples category into Virtual Reality category.